### PR TITLE
Update the default Pharo image version to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,17 @@ LABEL maintainer="Masashi Umezawa <ume@softumeya.com>"
 
 ## Install prerequisites and utilities
 RUN apt-get update && apt-get install -y \
-  libssl1.1 \
   libaudio2 \
   unzip \
   && rm -rf /var/lib/apt/lists/*
+
+## OpenSSL
+# The Pharo VM requires OpenSSL 1.1.0g, which is not available in the default Ubuntu 22.04 repositories.
+# The following commands download and install the required version of OpenSSL.
+# Note: This is a workaround and may not be the best practice for production environments.
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+  dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+  rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 
 # --------------------
 # Pharo

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ LABEL maintainer="Masashi Umezawa <ume@softumeya.com>"
 
 ## Install prerequisites and utilities
 RUN apt-get update && apt-get install -y \
-    libssl1.1 \
-    libaudio2 \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+  libssl1.1 \
+  libaudio2 \
+  unzip \
+  && rm -rf /var/lib/apt/lists/*
 
 # --------------------
 # Pharo
 # --------------------
 ENV DISPLAY=:0 
-ARG PHARO_IMAGE_VERSION=110
+ARG PHARO_IMAGE_VERSION=120
 ENV PHARO_MODE='gui'
 ENV PHARO_IMAGE='Pharo.image'
 ARG PHARO_DEFAULT_IMAGE_DIR='/root/data'
@@ -21,12 +21,12 @@ ENV PHARO_START_SCRIPT=${PHARO_DEFAULT_IMAGE_DIR}/config/default-startup.st
 
 RUN mkdir pharo && cd pharo \
   && apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    unzip \
+  curl \
+  unzip \
   && curl https://get.pharo.org/64/${PHARO_IMAGE_VERSION}+vm | bash \
   && mv ../pharo /usr/local/bin/ \
   && apt-get remove -y \
-    unzip \
+  unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/local/bin/pharo:${PATH}"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker run --name my_pharo -d -p 5900:5900 -p 6901:6901 mumez/pharo-vnc-supervis
 You can access the running pharo image via VNC client or web browser.
 (the default password is 'vncpassword')
 
-- VNC client:  `yourhost:5900`
+- VNC client: `yourhost:5900`
 - Web browser: `http://yourhost:6901/?password=vncpassword`
 
 ### How to start with a customized Pharo image
@@ -67,13 +67,13 @@ docker run --rm -p 5900:5900 -p 6901:6901 \
 	save-pharo get Tarantube
 ```
 
-### How to change default Pharo image version 
+### How to change default Pharo image version
 
-By default, Pharo 11.0 will be installed to the docker image. You can specify other versions when building a docker image.
+By default, Pharo 12.0 will be installed to the docker image. You can specify other versions when building a docker image.
 
 ```bash
-docker build -t pharo120-vnc-supervisor --build-arg PHARO_IMAGE_VERSION=120 .
-docker run --name my_pharo120 -d -p 5900:5900 -p 6901:6901 pharo120-vnc-supervisor
+docker build -t pharo130-vnc-supervisor --build-arg PHARO_IMAGE_VERSION=130 .
+docker run --name my_pharo130 -d -p 5900:5900 -p 6901:6901 pharo130-vnc-supervisor
 ```
 
 ## Settings


### PR DESCRIPTION
This pull request updates the Dockerfile and README to address OpenSSL compatibility and to upgrade the default Pharo image version. The key changes include adding a workaround for installing OpenSSL 1.1.0g and updating the default Pharo version from 11.0 to 12.0.

### OpenSSL Compatibility:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R22): Added a workaround to download and install OpenSSL 1.1.0g, which is required by the Pharo VM but not available in the default Ubuntu 22.04 repositories. This involves using `wget` and `dpkg` to manually install the library.

### Pharo Version Upgrade:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R22): Updated the default `PHARO_IMAGE_VERSION` from 110 (Pharo 11.0) to 120 (Pharo 12.0).
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R76): Updated the example commands to reflect the new default Pharo version (12.0) and provided instructions for building and running a Docker image with Pharo 13.0.