### PR TITLE
Upgrade default Pharo image to 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,11 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 
-## OpenSSL
-# The Pharo VM requires OpenSSL 1.1.0g, which is not available in the default Ubuntu 22.04 repositories.
-# The following commands download and install the required version of OpenSSL.
-# Note: This is a workaround and may not be the best practice for production environments.
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-  dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-  rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-
 # --------------------
 # Pharo
 # --------------------
 ENV DISPLAY=:0 
-ARG PHARO_IMAGE_VERSION=120
+ARG PHARO_IMAGE_VERSION=130
 ENV PHARO_MODE='gui'
 ENV PHARO_IMAGE='Pharo.image'
 ARG PHARO_DEFAULT_IMAGE_DIR='/root/data'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 FROM mumez/ubuntu-vnc-supervisor
 LABEL maintainer="Masashi Umezawa <ume@softumeya.com>"
 
-## Install prerequisites and utilities
-RUN apt-get update && apt-get install -y \
-  libaudio2 \
-  unzip \
-  && rm -rf /var/lib/apt/lists/*
-
 # --------------------
 # Pharo
 # --------------------
@@ -18,15 +12,18 @@ ARG PHARO_DEFAULT_IMAGE_DIR='/root/data'
 ENV PHARO_HOME=${PHARO_DEFAULT_IMAGE_DIR}
 ENV PHARO_START_SCRIPT=${PHARO_DEFAULT_IMAGE_DIR}/config/default-startup.st
 
-RUN mkdir pharo && cd pharo \
-  && apt-get update && apt-get install -y --no-install-recommends \
+## Single RUN: install deps + Pharo, then purge apt cache and temp tools
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  libaudio2 \
+  unzip \
   curl \
-  unzip \
-  && curl https://get.pharo.org/64/${PHARO_IMAGE_VERSION}+vm | bash \
+  && mkdir pharo && cd pharo \
+  && curl -fsSL https://get.pharo.org/64/${PHARO_IMAGE_VERSION}+vm | bash \
   && mv ../pharo /usr/local/bin/ \
-  && apt-get remove -y \
-  unzip \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get purge -y --auto-remove unzip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache
 
 ENV PATH="/usr/local/bin/pharo:${PATH}"
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ docker run --rm -p 5900:5900 -p 6901:6901 \
 
 ### How to change default Pharo image version
 
-By default, Pharo 12.0 will be installed to the docker image. You can specify other versions when building a docker image.
+By default, Pharo 13.0 will be installed to the docker image. You can specify other versions when building a docker image.
 
 ```bash
-docker build -t pharo130-vnc-supervisor --build-arg PHARO_IMAGE_VERSION=130 .
-docker run --name my_pharo130 -d -p 5900:5900 -p 6901:6901 pharo130-vnc-supervisor
+docker build -t pharo140-vnc-supervisor --build-arg PHARO_IMAGE_VERSION=140 .
+docker run --name my_pharo140 -d -p 5900:5900 -p 6901:6901 pharo140-vnc-supervisor
 ```
 
 ## Settings

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ docker run --name my_pharo -d -p 5900:5900 -p 6901:6901 \
 	mumez/pharo-vnc-supervisor
 ```
 
+**Note for Windows (Git Bash / MSYS):** The colon in `:/root/data` can be mangled by the shell, so the host directory may not mount correctly. Use one of these:
+
+- Prevent path conversion: `MSYS_NO_PATHCONV=1 docker run ... -v /c/Users/YourUser/docker/pharo/data:/root/data ...`
+- Or use a Windows-style path: `-v C:/Users/YourUser/docker/pharo/data:/root/data`
+
 ### How to build a customized Pharo image in a container
 
 You can use `save-pharo` command to build a customized Pharo image.
@@ -38,6 +43,7 @@ You can use `save-pharo` command to build a customized Pharo image.
 
 ```bash
 REPOS_URL=github://mumez/Tarantalk/repository
+# On Windows (Git Bash), use: MSYS_NO_PATHCONV=1 docker run ... -v /c/Users/ume/docker/pharo/data:/root/data ...
 docker run --rm -p 5900:5900 -p 6901:6901 \
 	-v=$HOME/docker/pharo/data:/root/data \
 	mumez/pharo-vnc-supervisor \
@@ -54,17 +60,6 @@ docker run --rm -p 5900:5900 -p 6901:6901 \
 	mumez/pharo-vnc-supervisor \
 	save-pharo config http://smalltalkhub.com/mc/Pharo/MetaRepoForPharo60/main/ \
 	ConfigurationOfNeo4reSt --install=stable
-```
-
-#### Install from Catalog (Obsolete - available before Pharo 6)
-
-`save-pharo get <Project name>`
-
-```bash
-docker run --rm -p 5900:5900 -p 6901:6901 \
-	-v=$HOME/docker/pharo/data:/root/data \
-	mumez/pharo-vnc-supervisor \
-	save-pharo get Tarantube
 ```
 
 ### How to change default Pharo image version

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ docker run --name my_pharo -d -p 5900:5900 -p 6901:6901 \
 	mumez/pharo-vnc-supervisor
 ```
 
-**Note for Windows (Git Bash / MSYS):** The colon in `:/root/data` can be mangled by the shell, so the host directory may not mount correctly. Use one of these:
-
-- Prevent path conversion: `MSYS_NO_PATHCONV=1 docker run ... -v /c/Users/YourUser/docker/pharo/data:/root/data ...`
-- Or use a Windows-style path: `-v C:/Users/YourUser/docker/pharo/data:/root/data`
+> **Note for Windows (Git Bash / MSYS):** The colon in `:/root/data` can be mangled by the shell, so the host directory may not mount correctly. Use one of these:
+>
+> - Prevent path conversion: `MSYS_NO_PATHCONV=1 docker run ... -v /c/Users/YourUser/docker/pharo/data:/root/data ...`
+> - Or use a Windows-style path: `-v C:/Users/YourUser/docker/pharo/data:/root/data`
 
 ### How to build a customized Pharo image in a container
 
@@ -42,12 +42,12 @@ You can use `save-pharo` command to build a customized Pharo image.
 `save-pharo metacello <metacello command-line arguments>`
 
 ```bash
-REPOS_URL=github://mumez/Tarantalk/repository
+REPOS_URL=github://mumez/PharoSmalltalkInteropServer:main/src
 # On Windows (Git Bash), use: MSYS_NO_PATHCONV=1 docker run ... -v /c/Users/ume/docker/pharo/data:/root/data ...
 docker run --rm -p 5900:5900 -p 6901:6901 \
 	-v=$HOME/docker/pharo/data:/root/data \
 	mumez/pharo-vnc-supervisor \
-	save-pharo metacello install $REPOS_URL BaselineOfTarantalk
+	save-pharo metacello install $REPOS_URL BaselineOfPharoSmalltalkInteropServer
 ```
 
 #### Install by Configuration

--- a/config/default-startup.st
+++ b/config/default-startup.st
@@ -1,2 +1,2 @@
-"For supressing lost-changes-recovery dialog on start-up"
+"For suppressing lost-changes-recovery dialog on start-up"
 EpLostChangesDetector enabled: false.

--- a/save-pharo.sh
+++ b/save-pharo.sh
@@ -4,7 +4,7 @@ ORIGDIR=`pwd`
 BASEDIR=/usr/local/bin/pharo
 PHARO_CHANGE=${PHARO_IMAGE%.image}.changes
 
-if [ -e /root/data/$PHATO_IMAGE ]; then
+if [ -e /root/data/$PHARO_IMAGE ]; then
   BASEDIR=/root/data
 fi
 
@@ -16,7 +16,7 @@ cp -f $BASEDIR/$PHARO_CHANGE $BLDDIR
 cd $BLDDIR
 
 if [ $# -lt 2 ]; then
-  echo "Usage: save-pharo.sh {get|config} command params" 1>&2
+  echo "Usage: save-pharo.sh {metacello|config} command params" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
- Default Pharo version: Bump default image from Pharo 12 (120) to Pharo 13 (130) via the PHARO_IMAGE_VERSION build arg.
- Dockerfile cleanup: Remove the manual OpenSSL 1.1 install (download/install of libssl1.1 from Ubuntu archive). This workaround was for the Pharo VM on Ubuntu 22.04; it is no longer needed for the current setup.