### PR TITLE
Add headless mode support to Pharo startup scripts

### DIFF
--- a/save-pharo.sh
+++ b/save-pharo.sh
@@ -22,7 +22,11 @@ fi
 
 echo "## Pharo starts: $@"
 
-pharo-ui $PHARO_IMAGE ${@:1}
+if [ "$PHARO_MODE" == "headless" ]; then
+    pharo -vm-display-null $PHARO_IMAGE ${@:1}
+else
+    pharo-ui $PHARO_IMAGE ${@:1}
+fi
 
 cp -f $PHARO_IMAGE /root/data/$PHARO_IMAGE
 cp -f $PHARO_CHANGE /root/data/$PHARO_CHANGE

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,8 @@ fi
 # supervisor log file
 mkdir -p $PHARO_HOME/logs && touch $PHARO_HOME/logs/$PHARO_SUPERVISOR_LOG_NAME
 
-# start base environments
-/usr/local/bin/setup-envs-all.sh &
-sleep 2
+# start base environments (skip in headless mode)
+if [ "$PHARO_MODE" != "headless" ]; then
+    /usr/local/bin/setup-envs-all.sh &
+    sleep 2
+fi


### PR DESCRIPTION
## Summary
This PR adds support for running Pharo in headless mode by introducing conditional logic based on a `PHARO_MODE` environment variable. When headless mode is enabled, the startup process skips GUI environment setup and uses the headless Pharo runtime instead of the UI variant.

## Key Changes
- **setup.sh**: Added conditional check to skip environment setup script (`setup-envs-all.sh`) when `PHARO_MODE` is set to "headless"
- **save-pharo.sh**: Added conditional logic to launch Pharo with `pharo -vm-display-null` in headless mode instead of `pharo-ui`

## Implementation Details
- The headless mode is controlled via the `PHARO_MODE` environment variable
- When `PHARO_MODE != "headless"`, the system behaves as before (GUI mode with full environment setup)
- When `PHARO_MODE == "headless"`, the system:
  - Skips the base environment setup that would normally initialize GUI components
  - Uses the null display driver (`-vm-display-null`) to run Pharo without a graphical interface
- All other functionality (image and change file handling) remains unchanged

https://claude.ai/code/session_01YNX4ccgJJCSeMYEUztY3ED